### PR TITLE
Revert "go: do not malloc for ab_append"

### DIFF
--- a/go/ab/ab.go
+++ b/go/ab/ab.go
@@ -142,7 +142,7 @@ func (n *Node) Append(data string) (uint64, uint64, error) {
 	n.appendResult = make(chan appendResult)
 	cData := C.CString(data)
 	defer C.free(unsafe.Pointer(cData))
-	C.append_go_gateway(n.ptr, cData, C.int(len(data)), unsafe.Pointer(&n.callbacksNum))
+	C.append_go_gateway(n.ptr, cData, C.int(len(data)), C.int(n.callbacksNum))
 	result := <-n.appendResult
 	n.appendResult = nil
 	if result.status == 0 {
@@ -210,7 +210,8 @@ func onLeaderChangeGoCb(id C.uint64_t, p unsafe.Pointer) {
 
 //export appendGoCb
 func appendGoCb(status C.int, round C.uint64_t, commit C.uint64_t, p unsafe.Pointer) {
-	i := *(*int)(p)
+	i := int(*(*C.int)(p))
+	C.free(p)
 	registeredNodesLock.RLock()
 	defer registeredNodesLock.RUnlock()
 	node := registeredNodes[i]

--- a/go/ab/callback.h
+++ b/go/ab/callback.h
@@ -16,5 +16,5 @@ void on_leader_change_go_cb_gateway(uint64_t leader_id, void* cb_data);
 
 void set_callbacks(ab_callbacks_t* callbacks);
 
-void append_go_gateway(ab_node_t* n, char* data, int data_len, void* argPtr);
+void append_go_gateway(ab_node_t* n, char* data, int data_len, int callbackNum);
 void appendGoCb(int status, uint64_t round, uint64_t commit, void* cb_data);

--- a/go/ab/callback_gw.go
+++ b/go/ab/callback_gw.go
@@ -33,8 +33,10 @@ void set_callbacks(ab_callbacks_t* callbacks) {
 	callbacks->on_leader_change = &on_leader_change_go_cb_gateway;
 }
 
-void append_go_gateway(ab_node_t* n, char* data, int data_len, void* cb_data) {
-	ab_append(n, data, data_len, appendGoCb, cb_data);
+void append_go_gateway(ab_node_t* n, char* data, int data_len, int callbackNum) {
+	int* argPtr = malloc(sizeof(int));
+	*argPtr = callbackNum;
+	ab_append(n, data, data_len, appendGoCb, argPtr);
 }
 */
 import "C"


### PR DESCRIPTION
Reverts Preetam/libab#25.

I believe this should fix #28.