### PR TITLE
Decrease commit latency

### DIFF
--- a/src/node/node.cc
+++ b/src/node/node.cc
@@ -62,7 +62,7 @@ Node :: run() {
 		auto self = (Node*)timer->data;
 		self->periodic();
 	},
-	16, 16);
+	50, 50);
 	return uv_run(m_uv_loop.get(), UV_RUN_DEFAULT);
 }
 

--- a/src/node/role.cc
+++ b/src/node/role.cc
@@ -17,8 +17,7 @@ Role :: periodic(uint64_t ts) {
 
 void
 Role :: periodic_leader(uint64_t ts) {
-	if (ts - m_leader_data->m_last_broadcast > 50e6 &&
-		m_leader_data->m_acks.size() >= m_cluster_size/2) {
+	if (m_leader_data->m_acks.size() >= m_cluster_size/2) {
 		uint64_t max_commit = m_commit;
 		for (auto it = m_leader_data->m_acks.begin(); it != m_leader_data->m_acks.end(); ++it) {
 			if (it->second > max_commit) {
@@ -242,6 +241,7 @@ Role :: handle_leader_active_ack(uint64_t ts, const LeaderActiveAck& msg) {
 
 	if (m_state == Leader) {
 		m_leader_data->m_acks[msg.id] = msg.committed;
+		periodic_leader(ts);
 	} else {
 		m_potential_leader_data->m_acks[msg.id] = msg.committed;
 	}

--- a/src/node/role.cc
+++ b/src/node/role.cc
@@ -17,6 +17,13 @@ Role :: periodic(uint64_t ts) {
 
 void
 Role :: periodic_leader(uint64_t ts) {
+	if (m_leader_data->m_pending_commit == 0) {
+		// No pending commit.
+		if (ts - m_leader_data->m_last_broadcast < 50e6) {
+			// Not enough time has passed to send a regular heartbeat.
+			return;
+		}
+	}
 	if (m_leader_data->m_acks.size() >= m_cluster_size/2) {
 		uint64_t max_commit = m_commit;
 		for (auto it = m_leader_data->m_acks.begin(); it != m_leader_data->m_acks.end(); ++it) {


### PR DESCRIPTION
* Increase periodic timer duration to 50 ms
* Call `periodic_leader` immediately after each ack
* Make sure we don't broadcast in under 50 ms if we don't have a pending message commit