### PR TITLE
Fix typo in encoding function names

### DIFF
--- a/src/message/encoding.h
+++ b/src/message/encoding.h
@@ -6,28 +6,28 @@
 extern "C" {
 #endif
 
-void write8be(uint8_t, uint8_t*);
-void write16be(uint16_t, uint8_t*);
-void write32be(uint32_t, uint8_t*);
-void write64be(uint64_t, uint8_t*);
+void write8le(uint8_t, uint8_t*);
+void write16le(uint16_t, uint8_t*);
+void write32le(uint32_t, uint8_t*);
+void write64le(uint64_t, uint8_t*);
 
-uint8_t read8be(uint8_t*);
-uint16_t read16be(uint8_t*);
-uint32_t read32be(uint8_t*);
-uint64_t read64be(uint8_t*);
+uint8_t read8le(uint8_t*);
+uint16_t read16le(uint8_t*);
+uint32_t read32le(uint8_t*);
+uint64_t read64le(uint8_t*);
 
 inline void
-write8be(uint8_t v, uint8_t* dest) {
+write8le(uint8_t v, uint8_t* dest) {
 	*dest = v;
 }
 
 inline uint8_t
-read8be(uint8_t* src) {
+read8le(uint8_t* src) {
 	return *src;
 }
 
 inline void
-write16be(uint16_t v, uint8_t* dest) {
+write16le(uint16_t v, uint8_t* dest) {
 	*dest = uint8_t(v);
 	dest++;
 	v >>= 8;
@@ -35,7 +35,7 @@ write16be(uint16_t v, uint8_t* dest) {
 }
 
 inline uint16_t
-read16be(uint8_t* src) {
+read16le(uint8_t* src) {
 	uint16_t v = *src;
 	src++;
 	v |= uint64_t(*src) << (8*1);
@@ -43,7 +43,7 @@ read16be(uint8_t* src) {
 }
 
 inline void
-write32be(uint32_t v, uint8_t* dest) {
+write32le(uint32_t v, uint8_t* dest) {
 	*dest = uint8_t(v);
 	dest++;
 	v >>= 8;
@@ -57,7 +57,7 @@ write32be(uint32_t v, uint8_t* dest) {
 }
 
 inline uint32_t
-read32be(uint8_t* src) {
+read32le(uint8_t* src) {
 	uint32_t v = *src;
 	src++;
 	v |= uint32_t(*src) << 8;
@@ -69,7 +69,7 @@ read32be(uint8_t* src) {
 }
 
 inline void
-write64be(uint64_t v, uint8_t* dest) {
+write64le(uint64_t v, uint8_t* dest) {
 	*dest = uint8_t(v);
 	dest++;
 	v >>= 8;
@@ -95,7 +95,7 @@ write64be(uint64_t v, uint8_t* dest) {
 }
 
 inline uint64_t
-read64be(uint8_t* src) {
+read64le(uint8_t* src) {
 	uint64_t v = *src;
 	src++;
 	v |= uint64_t(*src) << (8*1);

--- a/src/message/message.cc
+++ b/src/message/message.cc
@@ -34,19 +34,19 @@ Message :: pack(uint8_t* dest, int dest_len) const {
 		return -1;
 	}
 
-	write32be(length, dest);
+	write32le(length, dest);
 	dest += 4;
 	dest_len -= 4;
 	memcpy(dest, nonce_hash, NONCE_HASH_SIZE);
 	dest += NONCE_HASH_SIZE;
 	dest_len -= NONCE_HASH_SIZE;
-	write8be(type, dest);
+	write8le(type, dest);
 	dest++;
 	dest_len--;
-	write8be(flags, dest);
+	write8le(flags, dest);
 	dest++;
 	dest_len--;
-	write64be(message_id, dest);
+	write64le(message_id, dest);
 	dest += 8;
 	dest_len -= 8;
 
@@ -68,18 +68,18 @@ Message :: unpack(uint8_t* src, int src_len) {
 		return -1;
 	}
 
-	uint32_t length = read32be(src);
+	uint32_t length = read32le(src);
 	src += 4;
 	if (src_len < length) {
 		return -2;
 	}
 	memcpy(nonce_hash, src, NONCE_HASH_SIZE);
 	src += NONCE_HASH_SIZE;
-	type = read8be(src);
+	type = read8le(src);
 	src++;
-	flags = read8be(src);
+	flags = read8le(src);
 	src++;
-	message_id = read64be(src);
+	message_id = read64le(src);
 	src += 8;
 	unpack_body(src, length - MSG_HEADER_SIZE);
 	return 0;
@@ -195,7 +195,7 @@ Codec :: decode_message_length(uint8_t* src, int src_len) {
 	if (src_len < 4) {
 		return -1;
 	}
-	uint32_t length = read32be(src);
+	uint32_t length = read32le(src);
 	return (int)length;
 }
 

--- a/src/message/message.hpp
+++ b/src/message/message.hpp
@@ -117,9 +117,9 @@ public:
 		if (dest_len < body_size()) {
 			return -1;
 		}
-		write64be(id, dest);
+		write64le(id, dest);
 		dest += 8;
-		write16be(address.size(), dest);
+		write16le(address.size(), dest);
 		dest += 2;
 		memcpy(dest, address.c_str(), address.size());
 		return 0;
@@ -131,9 +131,9 @@ public:
 		if (src_len < body_size()) {
 			return -1;
 		}
-		id = read64be(src);
+		id = read64le(src);
 		src += 8;
-		uint16_t address_size = read16be(src);
+		uint16_t address_size = read16le(src);
 		src += 2;
 		if (src_len < 8 + 2 + address_size) {
 			return -2;
@@ -171,9 +171,9 @@ public:
 		if (dest_len < body_size()) {
 			return -1;
 		}
-		write64be(id, dest);
+		write64le(id, dest);
 		dest += 8;
-		write16be(address.size(), dest);
+		write16le(address.size(), dest);
 		dest += 2;
 		memcpy(dest, address.c_str(), address.size());
 		return 0;
@@ -185,9 +185,9 @@ public:
 		if (src_len < body_size()) {
 			return -1;
 		}
-		id = read64be(src);
+		id = read64le(src);
 		src += 8;
-		uint16_t address_size = read16be(src);
+		uint16_t address_size = read16le(src);
 		src += 2;
 		if (src_len < 8 + 2 + address_size) {
 			return -2;
@@ -247,15 +247,15 @@ public:
 		if (dest_len < body_size()) {
 			return -1;
 		}
-		write64be(id, dest);
+		write64le(id, dest);
 		dest += 8;
-		write64be(seq, dest);
+		write64le(seq, dest);
 		dest += 8;
-		write64be(round, dest);
+		write64le(round, dest);
 		dest += 8;
-		write64be(next, dest);
+		write64le(next, dest);
 		dest += 8;
-		write32be(next_content.size(), dest);
+		write32le(next_content.size(), dest);
 		dest += 4;
 		memcpy(dest, next_content.c_str(), next_content.size());
 		return 0;
@@ -267,15 +267,15 @@ public:
 		if (src_len < body_size()) {
 			return -1;
 		}
-		id = read64be(src);
+		id = read64le(src);
 		src += 8;
-		seq = read64be(src);
+		seq = read64le(src);
 		src += 8;
-		round = read64be(src);
+		round = read64le(src);
 		src += 8;
-		next = read64be(src);
+		next = read64le(src);
 		src += 8;
-		uint32_t next_content_size = read32be(src);
+		uint32_t next_content_size = read32le(src);
 		src += 4;
 		if (src_len < 8+8+8+8+4 + next_content_size) {
 			return -2;
@@ -323,11 +323,11 @@ public:
 		if (dest_len < body_size()) {
 			return -1;
 		}
-		write64be(id, dest);
+		write64le(id, dest);
 		dest += 8;
-		write64be(seq, dest);
+		write64le(seq, dest);
 		dest += 8;
-		write64be(round, dest);
+		write64le(round, dest);
 		return 0;
 	}
 
@@ -337,11 +337,11 @@ public:
 		if (src_len < body_size()) {
 			return -1;
 		}
-		id = read64be(src);
+		id = read64le(src);
 		src += 8;
-		seq = read64be(src);
+		seq = read64le(src);
 		src += 8;
-		round = read64be(src);
+		round = read64le(src);
 		return 0;
 	}
 


### PR DESCRIPTION
The names suggest big endian but these are all little endian.